### PR TITLE
feature: implement scheduled job to cancel old  pending invoices

### DIFF
--- a/invoice/src/main/java/az/cybernet/invoice/InvoiceApplication.java
+++ b/invoice/src/main/java/az/cybernet/invoice/InvoiceApplication.java
@@ -3,9 +3,11 @@ package az.cybernet.invoice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients(basePackages = "az.cybernet.invoice.client")
+@EnableScheduling
 public class InvoiceApplication {
 
     public static void main(String[] args) {

--- a/invoice/src/main/java/az/cybernet/invoice/mapper/InvoiceMapper.java
+++ b/invoice/src/main/java/az/cybernet/invoice/mapper/InvoiceMapper.java
@@ -36,4 +36,6 @@ public interface InvoiceMapper {
                       @Param("comment") String comment,
                       @Param("total") Double total,
                       @Param("updatedAt") LocalDateTime updatedAt);
+
+    List<Invoice> findOldPendingInvoices(@Param("date") LocalDateTime date);
 }

--- a/invoice/src/main/java/az/cybernet/invoice/scheduler/InvoiceCancellationScheduler.java
+++ b/invoice/src/main/java/az/cybernet/invoice/scheduler/InvoiceCancellationScheduler.java
@@ -1,0 +1,23 @@
+package az.cybernet.invoice.scheduler;
+
+import az.cybernet.invoice.service.InvoiceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InvoiceCancellationScheduler {
+
+    private final InvoiceService invoiceService;
+
+    // This will run at 01:00 AM every day
+    @Scheduled(cron = "0 0 1 * * ?")
+    public void cancelOldPendingInvoices() {
+        log.info("Starting scheduled job to cancel old pending invoices...");
+        invoiceService.cancelOldPendingInvoices();
+        log.info("Finished scheduled job.");
+    }
+}

--- a/invoice/src/main/java/az/cybernet/invoice/service/InvoiceService.java
+++ b/invoice/src/main/java/az/cybernet/invoice/service/InvoiceService.java
@@ -27,4 +27,6 @@ public interface InvoiceService {
     InvoiceResponse approveInvoice(UUID id);
 
     ResponseEntity<byte[]> getInvoicePdf(UUID id);
+
+    void cancelOldPendingInvoices();
 }

--- a/invoice/src/main/java/az/cybernet/invoice/service/impl/InvoiceServiceImpl.java
+++ b/invoice/src/main/java/az/cybernet/invoice/service/impl/InvoiceServiceImpl.java
@@ -213,4 +213,35 @@ public class InvoiceServiceImpl implements InvoiceService {
         return mapstruct.toDto(invoice);
 
     }
+
+    @Override
+    @Transactional
+    public void cancelOldPendingInvoices() {
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+        List<Invoice> oldInvoices = mapper.findOldPendingInvoices(oneMonthAgo);
+
+        if (oldInvoices.isEmpty()) {
+            log.info("No pending invoices older than one month found to cancel.");
+            return;
+        }
+
+        log.info("Found {} old pending invoices to cancel.", oldInvoices.size());
+
+        for (Invoice invoice : oldInvoices) {
+            invoice.setStatus(Status.CANCELLED);
+            invoice.setUpdatedAt(LocalDateTime.now());
+            invoice.setComment("Automatically cancelled due to being in PENDING status for over a month.");
+
+            mapper.updateInvoice(
+                    invoice.getId(),
+                    invoice.getStatus(),
+                    invoice.getComment(),
+                    invoice.getTotal(),
+                    invoice.getUpdatedAt()
+            );
+
+            InvoiceOperation operation = mapstruct.invoiceToInvcOper(invoice);
+            invoiceOperationMapper.insertInvoiceOperation(operation);
+        }
+    }
 }

--- a/invoice/src/main/resources/application-local.yaml
+++ b/invoice/src/main/resources/application-local.yaml
@@ -4,7 +4,7 @@ server:
 
 spring:
   datasource:
-    url: jdbc:postgresql://postgres-db:5432/${INVOICE_DB_NAME:invoice}
+    url: jdbc:postgresql://localhost:5432/${INVOICE_DB_NAME:invoice}
     username: ${INVOICE_DB_USER:invoice}
     password: ${INVOICE_DB_PASS:invoice_pass}
 

--- a/invoice/src/main/resources/mappers/InvoiceMapper.xml
+++ b/invoice/src/main/resources/mappers/InvoiceMapper.xml
@@ -112,4 +112,10 @@
         WHERE id = #{id}
     </update>
 
+    <select id="findOldPendingInvoices" resultType="az.cybernet.invoice.entity.Invoice">
+        SELECT *
+        FROM invoice.invoice
+        WHERE status = 'PENDING' AND updated_at &lt;= #{date}
+    </select>
+
 </mapper>


### PR DESCRIPTION
this feature implements the cancellation of any invoice that has been in the PENDING status for more than one month without any updates.

Enabled Application-Wide Scheduling: Added the @EnableScheduling annotation to InvoiceApplication.java to activate the scheduling capabilities of Spring Boot.

Created Invoice Cancellation Scheduler:
A new class InvoiceCancellationScheduler was created in the az.cybernet.invoice.scheduler package.
This scheduler is configured with a cron expression (@Scheduled(cron = "0 0 1 * * ?")) to run once every day at 1:00 AM.

Updated Database Layer (InvoiceMapper):
Added a new findOldPendingInvoices method to InvoiceMapper.java and its corresponding SQL query in InvoiceMapper.xml to fetch all invoices with a PENDING status and an updated_at timestamp older than a given date.

Implemented Service Logic (InvoiceServiceImpl):
The core logic is implemented in the cancelOldPendingInvoices method.
This method calculates the date one month in the past and uses the new mapper method to find eligible invoices.
For each old invoice found, its status is updated to CANCELLED, and a new entry is created in the invoice_operation table to log this automated action.